### PR TITLE
Add default arguments for course and search commands

### DIFF
--- a/commands/schedge/course.js
+++ b/commands/schedge/course.js
@@ -119,9 +119,34 @@ module.exports = {
   description: "Get the sections for a course",
   cooldown: 5,
   args: true,
-  usage: "<year> <semester-code: [su, fa, sp, ja]> <subject>-<school> <code>",
+  usage: "[<year> <semester-code: [su, fa, sp, ja]>] <subject>-<school> <code>",
   execute: async (message, args) => {
-    const [year, semester, schoolCode, deptCourseId] = args;
+    let year, semester, schoolCode, deptCourseId;
+    if (args.length >= 4){
+      [year, semester, schoolCode, deptCourseId] = args;
+    }
+    //try to auto-detect current year and semester
+    else if (args.length >= 2){
+      [schoolCode, deptCourseId] = args;
+      year = new Date().getFullYear();
+      month = new Date().getMonth();
+      //Jan
+      if (month == 0){
+        semester = "ja";
+      }
+      //Feb-May
+      else if (month <= 4){
+        semester = "sp";
+      }
+      //Jun-Aug
+      else if (month <= 7){
+        semester = "su";
+      }
+      //Sep-Dec
+      else{
+        semester = "fa";
+      }
+    }
     const filter = (reaction, user) =>
       (reaction.emoji.name === nextPageEmoji ||
         reaction.emoji.name === prevPageEmoji) &&

--- a/commands/schedge/search.js
+++ b/commands/schedge/search.js
@@ -39,9 +39,36 @@ module.exports = {
   description: "Search for NYU courses",
   cooldown: 5,
   args: true,
-  usage: "<year> <semester-code: [su, fa, sp, ja]> <query>",
+  usage: "[<year> <semester-code: [su, fa, sp, ja]>] <query>",
   execute: async (message, args) => {
-    const [year, semester, ...query] = args;
+    let year, semester, query;
+    if (args.length >= 3
+      && args[0].match(/[0-9]{4}/) != null
+      && ["ja", "sp", "su", "fa"].indexOf(args[1]) != -1){
+      [year, semester, ...query] = args;
+    }
+    //try to auto-detect current year and semester
+    else if (args.length >= 2){
+      [...query] = args;
+      year = new Date().getFullYear();
+      month = new Date().getMonth();
+      //Jan
+      if (month == 0){
+        semester = "ja";
+      }
+      //Feb-May
+      else if (month <= 4){
+        semester = "sp";
+      }
+      //Jun-Aug
+      else if (month <= 7){
+        semester = "su";
+      }
+      //Sep-Dec
+      else{
+        semester = "fa";
+      }
+    }
     const filter = (reaction, user) =>
       (reaction.emoji.name === nextPageEmoji ||
         reaction.emoji.name === prevPageEmoji) &&


### PR DESCRIPTION
The year and semester* will be automatically detected if the user does not input those two values.

* Semester detection is not 100% correct due to the changing of dates on a yearly basis.

Ref: #1

Co-authored-by: Andy Huang <ahuang-noreply@protonmail.com>