### PR TITLE
Show corresponding message when course not found in course command

### DIFF
--- a/commands/schedge/course.js
+++ b/commands/schedge/course.js
@@ -165,7 +165,7 @@ module.exports = {
       });
       const course = data.filter((c) => c.deptCourseId === deptCourseId)[0];
       // console.log(course);
-      if (course.sections.length === 0) {
+      if (!course || course.sections.length === 0) {
         message.channel.send({
           embed: {
             color: 0xcf000e,


### PR DESCRIPTION
Closes #6

Added an extra check in `course` command in case the course is not included at all in the api response